### PR TITLE
fix: use copy_files_to_bin_actions

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "db4ba7a486ca9707ea42a25cfdf14c93338cf45f8f5358f4720a955c31f9e942",
+  "moduleFileHash": "f4179e38229ac4f6c30b48b034fb8abf1c8c8df23a16b09beb8338c5f022ab39",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -18,7 +18,7 @@
   "moduleDepGraph": {
     "<root>": {
       "name": "rules_mjml",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "key": "<root>",
       "repoName": "rules_mjml",
       "executionPlatformsToRegister": [],


### PR DESCRIPTION
We need to use copy_files_to_bin_actions otherwise source and generated files will use different trees.